### PR TITLE
feat: Integrate live queue count from API into frontend

### DIFF
--- a/src/pages/CustomerPortal.tsx
+++ b/src/pages/CustomerPortal.tsx
@@ -12,10 +12,11 @@ const CustomerPortal = () => {
   const {
     queue,
     currentServing,
-    queueLength,
     currentToken,
     getToken,
-    getEstimatedWaitTime
+    getEstimatedWaitTime,
+    liveQueueCount,
+    liveEstimatedWaitTime,
   } = useQueue();
 
   const [isGettingToken, setIsGettingToken] = useState(false);
@@ -59,9 +60,9 @@ const CustomerPortal = () => {
         {/* Queue Status Display */}
         <QueueDisplay
           currentServing={currentServing}
-          queueLength={queueLength}
+          queueLength={liveQueueCount}
           nextToken={queue[0]?.number}
-          estimatedWaitTime={currentPosition && estimatedWait !== 'N/A' ? estimatedWait : undefined}
+          estimatedWaitTime={liveEstimatedWaitTime}
         />
 
         {/* Token Management */}


### PR DESCRIPTION
This commit modifies the frontend to display a live queue count fetched from the `/api/queue` endpoint. The `useQueue` hook has been updated to poll this endpoint every 4 seconds, providing a real-time view of the number of people in the queue.

- Adds state to `useQueue.ts` for live queue count and estimated wait time.
- Implements a `useEffect` in `useQueue.ts` to fetch data from `/api/queue` at a regular interval.
- Updates `CustomerPortal.tsx` to use the new live data and pass it to the `QueueDisplay` component.
- The `QueueDisplay` component now shows the live queue length and an estimated wait time based on this count, while the token system continues to operate independently.