### PR TITLE
feat: Integrate live queue count from API into frontend

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:5000',
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
This commit modifies the frontend to display a live queue count fetched from the `/api/queue` endpoint. The `useQueue` hook has been updated to poll this endpoint every 4 seconds, providing a real-time view of the number of people in the queue.

- Adds state to `useQueue.ts` for live queue count and estimated wait time.
- Implements a `useEffect` in `useQueue.ts` to fetch data from `/api/queue` at a regular interval.
- Updates `CustomerPortal.tsx` to use the new live data and pass it to the `QueueDisplay` component.
- The `QueueDisplay` component now shows the live queue length and an estimated wait time based on this count, while the token system continues to operate independently.
- Adds a proxy configuration to `vite.config.ts` to correctly forward API requests to the backend server during development.