### PR TITLE
fix: Relax RLS policy for token creation

### DIFF
--- a/supabase/migrations/20250907103800_fix_token_creation_policy.sql
+++ b/supabase/migrations/20250907103800_fix_token_creation_policy.sql
@@ -1,0 +1,9 @@
+-- Drop the old, incorrect policy that required authenticated users
+DROP POLICY IF EXISTS "Allow authenticated users to create tokens" ON public.tokens;
+
+-- Create a new policy to allow any user (including anonymous) to create tokens.
+-- The `public` role includes `anon` (unauthenticated users) and `authenticated` users.
+CREATE POLICY "Allow public access to create tokens"
+ON public.tokens FOR INSERT
+TO public
+WITH CHECK (true);


### PR DESCRIPTION
This commit fixes a bug where anonymous users could not create tokens because the Row Level Security policy was too restrictive.

The policy on the `tokens` table now allows insertions from the `public` role, which includes anonymous users, aligning with the application's requirement for a public-facing customer portal.