### PR TITLE
fix: Consolidate RLS policy fixes for token creation

### DIFF
--- a/supabase/migrations/20250907103800_fix_token_creation_policy.sql
+++ b/supabase/migrations/20250907103800_fix_token_creation_policy.sql
@@ -2,8 +2,18 @@
 DROP POLICY IF EXISTS "Allow authenticated users to create tokens" ON public.tokens;
 
 -- Create a new policy to allow any user (including anonymous) to create tokens.
--- The `public` role includes `anon` (unauthenticated users) and `authenticated` users.
 CREATE POLICY "Allow public access to create tokens"
 ON public.tokens FOR INSERT
 TO public
+WITH CHECK (true);
+
+-- Drop the old, incorrect policy that required admin users to update system state
+DROP POLICY IF EXISTS "Allow admins to update system state" ON public.system_state;
+
+-- Create a new policy to allow any user to update the system state.
+-- This is necessary so that getting a token can also increment the next_token_number.
+CREATE POLICY "Allow public access to update system state"
+ON public.system_state FOR UPDATE
+TO public
+USING (true)
 WITH CHECK (true);


### PR DESCRIPTION
This commit updates the previous migration to fix two related permission issues:

1.  The RLS policy for the `tokens` table is relaxed to allow anonymous users to create tokens.
2.  The RLS policy for the `system_state` table is relaxed to allow anonymous users to update it, which is a necessary second step for the `getToken` function to succeed.

This single, consolidated migration ensures that the entire token creation process can be executed by a public, unauthenticated user.